### PR TITLE
Import magento

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,18 @@ BACKEND_FRONTNAME="management"
 If you want to use different parameters change the values in the [.env](.env) file to your needs.
 After customizing the parameters just run trigger the installation with `bin/console install <hostname>`.
 
+## Import
+
+The `import` action gives you the ability to set up your existing project. You only need to place you database sql file(s) into `config/mysql/` and provide the following parameters.
+
+```bash
+bin/console import <hostname> [crypt]
+```
+
+This will detect if your Magento project is an Enterprise or Community version and download an env.php template and fill it up automatically.
+
+The `crypt` parameter is optional but we recommend to provide it based on the original env.php file.
+
 ## Licensing
 
 dockerize-magento2 is licensed under the Apache License, Version 2.0.

--- a/bin/console
+++ b/bin/console
@@ -327,7 +327,7 @@ importMagento() {
   # delete env.php if exists
   rm app/etc/env.php
 
-  if grep -Fxq "magento/product-enterprise-edition" composer.json
+  if [ grep -Fxq "magento/product-enterprise-edition" composer.json ] || [ grep -Fxq "magento/project-enterprise-edition" composer.json ]
   then
     curl -k -o-  https://raw.githubusercontent.com/fsspencer/magento2-env-sample/master/ee/env.php > app/etc/env.php
   else

--- a/bin/console
+++ b/bin/console
@@ -271,6 +271,116 @@ installMagento() {
 }
 
 #######################################
+# Import Existing Magento
+# Globals:
+#   DATABASE_NAME
+#   DATABASE_USER
+#   DATABASE_PASSWORD
+#   ADMIN_USERNAME
+#   ADMIN_FIRSTNAME
+#   ADMIN_LASTNAME
+#   ADMIN_EMAIL
+#   ADMIN_PASSWORD
+#   DEFAULT_LANGUAGE
+#   DEFAULT_CURRENCY
+#   DEFAULT_TIMEZONE
+#   BACKEND_FRONTNAME
+# Arguments:
+#   hostname
+#   crypt [optional]
+# Returns:
+#   None
+#######################################
+importMagento() {
+
+  # get the hostname from the arguments
+  hostname=$1
+  if [ -z "$hostname" ]; then
+    echo >&2 "Please specify a hostname for your Magento shop (e.g. \"www.example.com\")\n"
+    echo >&2 "Usage:\n"
+    echo >&2 "  $SCRIPTNAME import www.example.com [6954a1ff91e2bb80bba35ebbaf35bcc9]"
+
+    exit 1
+  fi
+
+  # get the crypt from the arguments
+  crypt=$2
+
+  # generate a SSL certificate
+  generateSSLCertificate $hostname
+  if [ $? -ne 0 ]; then
+    exit 1
+  fi
+
+  # Add write permissions for pub folder
+  chmod -R g+w pub
+
+  # Start docker containers (docker-compose > v1.6 and docker > v1.10 required)
+  restart
+
+  # wait for MySQL to come up
+  sleep 30
+
+  # delete var directory 
+  rm -rf var/*
+
+  # delete env.php if exists
+  rm app/etc/env.php
+
+  if grep -Fxq "magento/product-enterprise-edition" composer.json
+  then
+    curl -k -o-  https://raw.githubusercontent.com/fsspencer/magento2-env-sample/master/ee/env.php > app/etc/env.php
+  else
+    curl -k -o-  https://raw.githubusercontent.com/fsspencer/magento2-env-sample/master/ce/env.php > app/etc/env.php
+  fi
+
+  # Install magento 2
+  baseURLInsecure="http://${hostname}/"
+  baseURLSecure="https://${hostname}/"
+  backendURL="https://${hostname}/${BACKEND_FRONTNAME}"
+
+  # replace env.php values
+  find "app/etc/env.php" -type f -exec sed -i "" "s/\[BACKEND_FRONTEND\]/${BACKEND_FRONTNAME}/g" {} \;
+  find "app/etc/env.php" -type f -exec sed -i "" "s/\[DB_HOST\]/mysql/g" {} \;
+  find "app/etc/env.php" -type f -exec sed -i "" "s/\[DB_NAME\]/${DATABASE_NAME}/g" {} \;
+  find "app/etc/env.php" -type f -exec sed -i "" "s/\[DB_USER\]/${DATABASE_USER}/g" {} \;
+  find "app/etc/env.php" -type f -exec sed -i "" "s/\[DB_PASSWORD\]/${DATABASE_PASSWORD}/g" {} \;
+
+  if [ ! -z "$crypt" ]; then
+    find "app/etc/env.php" -type f -exec sed -i "" "s/\[CRYPT\]/${crypt}/g" {} \;
+  fi
+
+  DATEINSTALL=$(php -r "echo date('r');")
+  find "app/etc/env.php" -type f -exec sed -i "" "s/\[DATE\]/${DATEINSTALL}/g" {} \;
+
+  # Import Magento database
+  docker-compose exec mysql /bin/bash /docker-entrypoint-initdb.d/import.sh ${DATABASE_ROOT_PASSWORD} ${DATABASE_USER} ${DATABASE_PASSWORD} ${DATABASE_NAME}
+
+  executeInDocker config:set web/unsecure/base_url ${baseURLSecure}
+  executeInDocker config:set web/secure/base_url ${baseURLInsecure}
+  executeInDocker admin:user:create --admin-firstname=${ADMIN_FIRSTNAME} --admin-lastname=${ADMIN_LASTNAME} --admin-email=${ADMIN_EMAIL} --admin-user=${ADMIN_USERNAME} --admin-password=${ADMIN_PASSWORD}
+
+  # Install and update modules
+  executeInDocker setup:upgrade
+
+  # Clear cache
+  executeInDocker cache:clean
+
+  # Index data
+  executeInDocker indexer:reindex
+
+  # Print results
+  echo "\n"
+  echo "Import complete.\n"
+
+  printf "%-15s%-30s\n" "Frontend" $baseURLInsecure
+  printf "%-15s%-30s\n" "Backend" $backendURL
+  printf "%-15s%s: %s\n" "" "Username" ${ADMIN_USERNAME}
+  printf "%-15s%s: %s\n" "" "Password" ${ADMIN_PASSWORD}
+
+}
+
+#######################################
 # Print the status of the server
 # Globals:
 #   None
@@ -380,6 +490,7 @@ usage() {
   echo ""
   echo "Actions:\n"
   printf "  %-15s%-30s\n" "install" "Install Magento"
+  printf "  %-15s%-30s\n" "import" "Import existing Magento"
   printf "  %-15s%-30s\n" "exec" "Execute bin/magento inside docker"
   echo ""
   printf "  %-15s%-30s\n" "start" "Start the server and all of its components"
@@ -392,6 +503,11 @@ case "$1" in
     install)
     shift 1
     installMagento $*
+    ;;
+
+    import)
+    shift 1
+    importMagento $*
     ;;
 
     exec)

--- a/config/mysql/import.sh
+++ b/config/mysql/import.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# Set the correct file permissions for Magento 2
+
+DATABASE_ROOT_PASSWORD=$1
+DATABASE_USER=$2
+DATABASE_PASSWORD=$3
+DATABASE_NAME=$4
+
+ /usr/bin/mysqld_safe & sleep 5s
+
+mysql -uroot -p${DATABASE_ROOT_PASSWORD} -e "SET GLOBAL show_compatibility_56 = ON;"
+
+# Import Magento database
+mysql -uroot -p${DATABASE_ROOT_PASSWORD} -e "DROP DATABASE IF EXISTS ${DATABASE_NAME};"
+mysql -uroot -p${DATABASE_ROOT_PASSWORD} -e "CREATE DATABASE ${DATABASE_NAME};"
+
+for SQL_FILE in /docker-entrypoint-initdb.d/*.sql
+do
+	mysql -u root -p${DATABASE_ROOT_PASSWORD} ${DATABASE_NAME} < ${SQL_FILE} 
+done
+
+mysql -uroot -p${DATABASE_ROOT_PASSWORD} -e "GRANT ALL PRIVILEGES ON ${DATABASE_NAME}.* TO '${DATABASE_USER}'@'%' IDENTIFIED BY '${DATABASE_PASSWORD}';"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
       MYSQL_PASSWORD: ${DATABASE_PASSWORD}
     volumes:
       - magento2mysqldata:/var/lib/mysql
+      - ./config/mysql/:/docker-entrypoint-initdb.d/
     networks:
       - back
 


### PR DESCRIPTION
## Import

The `import` action gives you the ability to set up your existing project. You only need to place you database sql file(s) into `config/mysql/` and provide the following parameters.

```bash
bin/console import <hostname> [crypt]
```

This will detect if your Magento project is an Enterprise or Community version and download an env.php template and fill it up automatically.

The `crypt` parameter is optional but we recommend to provide it based on the original env.php file.